### PR TITLE
Added OpenAI integration to generate subtasks for tasks

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -63,7 +63,7 @@
                             <div class="textarea-wrapper">
                                 <textarea name="description" class="description-textarea" id="textarea-{{ task.id }}"
                                     oninput="autoResize(this);">{{ task.description }}</textarea>
-                                <button type="button" class="ai-button">
+                                <button type="button" class="ai-button" onclick="generateSubtasks({{ task.id }});">
                                     ✨
                                 </button>
                             </div>
@@ -103,6 +103,18 @@
                 autoResize(textarea);
             });
         });
+
+        function generateSubtasks(taskId) {
+            fetch(`/generate_subtasks/${taskId}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }).then(response => response.json())
+              .then(data => {
+                  alert(data.message);
+              });
+        }
     </script>
 </body>
 


### PR DESCRIPTION
This pull request adds OpenAI integration to generate subtasks for tasks. The new route `/generate_subtasks/<int:task_id>` is added to call the OpenAI API and generate subtasks for a given task. The `index.html` is updated to include a new button with class `ai-button` that triggers the `generateSubtasks` function when clicked. The OpenAI requests only return a maximum of 6 subtasks and nothing else. The API key is stored in the `OPENAI_API_KEY` environment variable. The request is triggered when the button with class `ai-button` is clicked.

This PR fixes #5