### PR TITLE
Add OpenAI integration for task subtask generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, render_template, request, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
+import os
+import requests
 
 # Initialize the Flask app
 app = Flask(__name__)
@@ -57,6 +59,39 @@ def complete_task(task_id):
     if task:
         task.completed = not task.completed  # Toggle the completed status
         db.session.commit()
+    return redirect(url_for('index'))
+
+
+
+
+
+@app.route('/generate_subtasks/<int:task_id>', methods=['POST'])
+def generate_subtasks(task_id):
+    task = Task.query.get(task_id)
+    if task:
+        api_key = os.getenv('OPENAI_API_KEY')
+        headers = {
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json'
+        }
+        data = {
+            'model': 'gpt-4o',
+            'messages': [
+                {
+                    'role': 'system',
+                    'content': 'You are an AI assistant that helps users divide their tasks into subtasks using OpenAI API. Only return a maximum of 6 subtasks and nothing else. Use the ChatCompletion endpoint.'
+                },
+                {
+                    'role': 'user',
+                    'content': task.description
+                }
+            ]
+        }
+        response = requests.post('https://api.openai.com/v1/chat/completions', headers=headers, json=data)
+        if response.status_code == 200:
+            subtasks = response.json().get('choices', [{}])[0].get('message', {}).get('content', [])
+            task.description += '\n\nSubtasks:\n' + '\n'.join(subtasks[:6])
+            db.session.commit()
     return redirect(url_for('index'))
 
 


### PR DESCRIPTION
Added a new route `/generate_subtasks/<int:task_id>` that triggers the OpenAI API to generate subtasks for a given task. The subtasks are appended to the task description. This request should be triggered when I click the button with class "ai-button" and we should add a route in flask that calls the OpenAI api. The subtasks should be appended to the task description. It is important that OpenAI requests only returns a maximum of 6 subtasks and nothing else. Use gpt-4o and ChatCompletion endpoint, make the call with requests library. API key is stored in OPENAI_API_KEY environment variable.

This PR fixes #5