### PR TITLE
Add subtask generation feature using OpenAI API

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, render_template, request, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
+import os
+import requests
 
 # Initialize the Flask app
 app = Flask(__name__)
@@ -57,6 +59,39 @@ def complete_task(task_id):
     if task:
         task.completed = not task.completed  # Toggle the completed status
         db.session.commit()
+    return redirect(url_for('index'))
+
+
+
+
+
+@app.route('/generate_subtasks/<int:task_id>', methods=['POST'])
+def generate_subtasks(task_id):
+    task = Task.query.get(task_id)
+    if task:
+        api_key = os.getenv('OPENAI_API_KEY')
+        headers = {
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json'
+        }
+        data = {
+            'model': 'gpt-4o',
+            'messages': [
+                {
+                    'role': 'system',
+                    'content': 'You are an AI assistant that generates subtasks for a given task title.'
+                },
+                {
+                    'role': 'user',
+                    'content': f'Generate up to 6 subtasks for the task titled '{task.title}'.'
+                }
+            ]
+        }
+        response = requests.post('https://api.openai.com/v1/chat/completions', headers=headers, json=data)
+        if response.status_code == 200:
+            subtasks = response.json().get('choices', [{}])[0].get('message', {}).get('content', 'No subtasks generated')
+            task.description += f'\n\nSubtasks:\n{subtasks}'
+            db.session.commit()
     return redirect(url_for('index'))
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -63,7 +63,7 @@
                             <div class="textarea-wrapper">
                                 <textarea name="description" class="description-textarea" id="textarea-{{ task.id }}"
                                     oninput="autoResize(this);">{{ task.description }}</textarea>
-                                <button type="button" class="ai-button">
+                                <button type="button" class="ai-button" onclick="generateSubtasks({{ task.id }});">
                                     ✨
                                 </button>
                             </div>
@@ -103,6 +103,18 @@
                 autoResize(textarea);
             });
         });
+
+        function generateSubtasks(taskId) {
+            fetch(`/generate_subtasks/${taskId}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }).then(response => response.json())
+              .then(data => {
+                  alert(data.message);
+              });
+        }
     </script>
 </body>
 


### PR DESCRIPTION
This pull request adds a feature to generate subtasks for a given task using the OpenAI API. The changes made include adding a new route `/generate_subtasks/<int:task_id>` in `app.py` that calls the OpenAI API to generate subtasks for a given task title. The subtasks are appended to the task description. Additionally, a new function `generateSubtasks` is added to `index.html` that triggers the `/generate_subtasks/<int:task_id>` route when the AI button is clicked. This feature will help in dividing tasks into subtasks and make it easier to manage them. The OpenAI API is called with the gpt-4o and ChatCompletion endpoint, and the API key is stored in the OPENAI_API_KEY environment variable. The request should be triggered when the button with class 'ai-button' is clicked.

This PR fixes #11