### PR TITLE
Add route to generate subtasks using OpenAI API

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, render_template, request, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
+import os
+import requests
 
 # Initialize the Flask app
 app = Flask(__name__)
@@ -57,6 +59,39 @@ def complete_task(task_id):
     if task:
         task.completed = not task.completed  # Toggle the completed status
         db.session.commit()
+    return redirect(url_for('index'))
+
+
+
+
+
+@app.route('/generate_subtasks/<int:task_id>', methods=['POST'])
+def generate_subtasks(task_id):
+    task = Task.query.get(task_id)
+    if task:
+        api_key = os.getenv('OPENAI_API_KEY')
+        headers = {
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json'
+        }
+        data = {
+            'model': 'gpt-4o',
+            'messages': [
+                {
+                    'role': 'system',
+                    'content': 'You are an AI assistant that helps divide tasks into subtasks using OpenAI API.'
+                },
+                {
+                    'role': 'user',
+                    'content': f'Divide the task titled '{task.title}' into a maximum of 6 subtasks.'
+                }
+            ]
+        }
+        response = requests.post('https://api.openai.com/v1/chat/completions', headers=headers, json=data)
+        if response.status_code == 200:
+            subtasks = response.json().get('choices', [{}])[0].get('message', {}).get('content', 'No subtasks generated')
+            task.description += f'\n\nSubtasks:\n{subtasks}'
+            db.session.commit()
     return redirect(url_for('index'))
 
 


### PR DESCRIPTION
This pull request adds a new route `/generate_subtasks/<int:task_id>` that triggers the OpenAI API to generate subtasks for a given task. The subtasks are appended to the task description. The route is triggered when the button with class `ai-button` is clicked. The OpenAI API is called using the `requests` library and the API key is stored in the `OPENAI_API_KEY` environment variable. The subtasks are generated based on the task title and are returned as a maximum of 6 subtasks using the `gpt-4o` and `ChatCompletion` endpoint.

This PR fixes #14