### PR TITLE
Feature request: Generating subtasks using external API

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, render_template, request, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
+import os
+import requests
 
 # Initialize the Flask app
 app = Flask(__name__)
@@ -57,6 +59,40 @@ def complete_task(task_id):
     if task:
         task.completed = not task.completed  # Toggle the completed status
         db.session.commit()
+    return redirect(url_for('index'))
+
+
+
+
+
+@app.route('/generate_subtasks/<int:task_id>', methods=['POST'])
+def generate_subtasks(task_id):
+    task = Task.query.get(task_id)
+    if task:
+        api_key = os.getenv('OPENAI_API_KEY')
+        headers = {
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json'
+        }
+        data = {
+            'model': 'gpt-4o',
+            'messages': [
+                {
+                    'role': 'system',
+                    'content': 'You are an AI assistant that generates subtasks based on a given task title.'
+                },
+                {
+                    'role': 'user',
+                    'content': task.title
+                }
+            ],
+            'max_tokens': 6
+        }
+        response = requests.post('https://api.openai.com/v1/chat/completions', headers=headers, json=data)
+        if response.status_code == 200:
+            subtasks = response.json().get('choices', [{}])[0].get('message', {}).get('content', [])
+            task.description += '\n\nSubtasks:\n' + '\n'.join(subtasks)
+            db.session.commit()
     return redirect(url_for('index'))
 
 


### PR DESCRIPTION
Added a new route `/generate_subtasks/<int:task_id>` that triggers the OpenAI API to generate subtasks based on the task title. The subtasks are appended to the task description. The request to OpenAI API should be triggered when the user clicks the button with class "ai-button". You should add a new route in app.py that calls the OpenAI API. The subtasks should be generated based on tasks title and subtasks should be appended to the task description so don't create a new field in the database but only append to the description attribute of the Task object. There should be a javascript function in templates/index.html so when user clicks the "ai-button", index.html will trigger the new route in app.py. The API key is stored in OPENAI_API_KEY environment variable. The request to OpenAI API should be made with gpt-4o and ChatCompletion endpoint, make the call with requests library. The request to OpenAI API should only return a maximum of 6 subtasks and nothing else.

This PR fixes #27